### PR TITLE
Basic functionality

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -11,7 +11,7 @@ import { Component, Vue } from 'vue-property-decorator';
 @Component({})
 export default class App extends Vue {
   public doTheThingZhuLi() {
-    this.$flows.start()
+    this.$flows.start('black')
   }
 }
 </script>

--- a/src/App.vue
+++ b/src/App.vue
@@ -23,6 +23,9 @@ export default class App extends Vue {
   -moz-osx-font-smoothing: grayscale;
   text-align: center;
   color: #2c3e50;
-  margin-top: 60px;
+  padding: 60px 10px 10px 10px;
+}
+body {
+  margin: 0;
 }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,7 @@
 <template>
   <div id="app">
     <p>This is a vue-modal-flows test app</p>
+    <button @click="doTheThingZhuLi">Show Modal</button>
   </div>
 </template>
 
@@ -9,7 +10,7 @@ import { Component, Vue } from 'vue-property-decorator';
 
 @Component({})
 export default class App extends Vue {
-  public created() {
+  public doTheThingZhuLi() {
     this.$flows.start()
   }
 }

--- a/src/MyComponent.vue
+++ b/src/MyComponent.vue
@@ -1,6 +1,6 @@
 <template>
   <p class="foobar">
-  <button @click="another">Another!</button>
+  <button @click="another">Start Red Modal!</button>
   <button @click="cancel">Cancel</button>
   Modals within modals!
   </p>
@@ -14,7 +14,7 @@ import Component from 'vue-class-component'
 @Component({})
 export default class MyComponent extends Vue {
   another(): void {
-    this.$flows.start()
+    this.$flows.start('red')
   }
   cancel(): void {
     this.$emit('cancel-flow')
@@ -22,7 +22,7 @@ export default class MyComponent extends Vue {
 }
 </script>
 
-<style>
+<style scoped>
 .foobar {
   background-color: rgba(0,0,0,0.2);
   margin: 0;

--- a/src/MyRedComponent.vue
+++ b/src/MyRedComponent.vue
@@ -1,0 +1,31 @@
+<template>
+  <p class="foobar">
+  <button @click="another">Start Black Modal</button>
+  <button @click="cancel">Cancel</button>
+  Modals within modals!
+  </p>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import Component from 'vue-class-component'
+
+// The @Component decorator indicates the class is a Vue component
+@Component({})
+export default class MyRedComponent extends Vue {
+  another(): void {
+    this.$flows.start('black')
+  }
+  cancel(): void {
+    this.$emit('cancel-flow')
+  }
+}
+</script>
+
+<style scoped>
+.foobar {
+  background-color: rgba(255,0,0,0.2);
+  color: red;
+  margin: 0;
+}
+</style>

--- a/src/custom-flows.ts
+++ b/src/custom-flows.ts
@@ -1,0 +1,16 @@
+import { Flow } from './vue-flows'
+import MyComponent from './MyComponent.vue'
+import MyRedComponent from './MyRedComponent.vue'
+
+const flows: Flow[] = [
+  {
+    key: 'black',
+    component: MyComponent
+  },
+  {
+    key: 'red',
+    component: MyRedComponent
+  }
+]
+
+export default flows;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,11 @@
 import Vue from 'vue'
 import App from './App.vue'
-import VueModalFlows from './plugins/vue-modal-flows'
+import { VueFlows, VueFlowsRoot } from './vue-flows'
 
 Vue.config.productionTip = false
 
-Vue.use(VueModalFlows)
+Vue.use(VueFlows)
 
 new Vue({
-  render: h => h(App),
+  render: h => h(VueFlowsRoot(App)),
 }).$mount('#app')

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,14 @@
 import Vue from 'vue'
 import App from './App.vue'
 import { VueFlows, VueFlowsRoot } from './vue-flows'
+import flows from './custom-flows'
 
 Vue.config.productionTip = false
 
-Vue.use(VueFlows)
+Vue.use(VueFlows, {
+  hideCovered: false,
+  flows,
+})
 
 new Vue({
   render: h => h(VueFlowsRoot(App)),

--- a/src/vue-flows/MyComponent.vue
+++ b/src/vue-flows/MyComponent.vue
@@ -1,0 +1,30 @@
+<template>
+  <p class="foobar">
+  <button @click="another">Another!</button>
+  <button @click="cancel">Cancel</button>
+  Modals within modals!
+  </p>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import Component from 'vue-class-component'
+
+// The @Component decorator indicates the class is a Vue component
+@Component({})
+export default class MyComponent extends Vue {
+  another(): void {
+    this.$flows.start()
+  }
+  cancel(): void {
+    this.$emit('cancel-flow')
+  }
+}
+</script>
+
+<style>
+.foobar {
+  background-color: rgba(0,0,0,0.2);
+  margin: 0;
+}
+</style>

--- a/src/vue-flows/flows-root.ts
+++ b/src/vue-flows/flows-root.ts
@@ -1,0 +1,44 @@
+import { VueConstructor } from 'vue';
+import { Vue, Component } from 'vue-property-decorator';
+
+interface HigherOrderComponent {
+  (foo: VueConstructor): VueConstructor;
+}
+
+const rootElementStyles = {
+  position: 'relative'
+}
+
+/*
+* This interface contains the methods used by the Flows Plugin
+* to create and control modals in the Flows root component
+*/
+export interface IFlowsRoot extends Vue {
+  start(): void;
+}
+
+const VueFlowsRoot: HigherOrderComponent = (foo) => {
+  /*
+  * We create the component type dynamically so that the user
+  * can just replace 'h(App)' with 'h(VueFlowsRoot(App))'
+  */
+  @Component({
+    render(h) {
+      return h('div', { style: rootElementStyles}, [
+        h(foo),
+        //Modals go here....
+      ])
+    },
+    mounted() {
+      this.$flows._attach(this as IFlowsRoot)
+    },
+  })
+  class FlowsRoot extends Vue implements IFlowsRoot {
+    public start(): void {
+
+    }
+  };
+  return FlowsRoot;
+}
+
+export default VueFlowsRoot

--- a/src/vue-flows/flows-root.ts
+++ b/src/vue-flows/flows-root.ts
@@ -5,6 +5,10 @@ const rootElementStyles = {
   position: 'relative'
 }
 
+const coveredStyles = {
+  visibility: 'hidden'
+}
+
 const modalStyles = {
   position: 'absolute',
   top: 0,
@@ -32,6 +36,10 @@ export class FlowsRoot extends Vue {
   }
 
   modals: VueConstructor[] = []
+
+  public shouldHide(index: number = -1) {
+    return this.$flows._hideCovered && this.modals.length > index + 1;
+  }
 }
 
 /*
@@ -42,11 +50,20 @@ export class FlowsRoot extends Vue {
 const VueFlowsRoot: (app: VueConstructor) => VueConstructor = (app) => {
   @Component<CFlowsRoot>({
     render(h) {
-      return h('div', { style: rootElementStyles }, [
-        h(app),
-        this.modals.map(
-          m => h(m, { style: modalStyles, on: { 'cancel-flow': this.cancel }}))
-      ])
+      return h('div',
+        { style: { rootElementStyles } },
+        [
+          h(app, { style: this.shouldHide() ? coveredStyles : {}}),
+          this.modals.map(
+            (m, i) => h(m,
+              {
+                style: this.shouldHide(i) ? coveredStyles : modalStyles,
+                on: { 'cancel-flow': this.cancel }
+              }
+            )
+          )
+        ]
+      )
     },
   })
   class CFlowsRoot extends FlowsRoot {};

--- a/src/vue-flows/flows.ts
+++ b/src/vue-flows/flows.ts
@@ -1,4 +1,6 @@
-import { IFlowsRoot } from './flows-root';
+import { FlowsRoot } from './flows-root';
+
+import MyComponent from './MyComponent.vue';
 
 export type FlowsOptions = {
   hideCovered: boolean
@@ -16,11 +18,19 @@ export default class Flows {
     this.hideCovered = resOptions.hideCovered;
   }
 
+  private root: FlowsRoot | null = null;
+
   public start() {
     //TODO: implement
-    console.log("Foobar");
+    if (this.root == null) {
+      console.error("No root attached")
+    }
+    else {
+      this.root.start(MyComponent)
+    }
   }
-  public _attach(t: IFlowsRoot) {
-
+  public _attach(t: FlowsRoot) {
+    this.root = t;
+    console.log("Root attached");
   }
 }

--- a/src/vue-flows/flows.ts
+++ b/src/vue-flows/flows.ts
@@ -1,0 +1,26 @@
+import { IFlowsRoot } from './flows-root';
+
+export type FlowsOptions = {
+  hideCovered: boolean
+}
+
+const defaultOptions: FlowsOptions = {
+  hideCovered: true,
+}
+
+export default class Flows {
+  private hideCovered: boolean;
+
+  constructor(options: FlowsOptions) {
+    const resOptions = { ...options, ...defaultOptions };
+    this.hideCovered = resOptions.hideCovered;
+  }
+
+  public start() {
+    //TODO: implement
+    console.log("Foobar");
+  }
+  public _attach(t: IFlowsRoot) {
+
+  }
+}

--- a/src/vue-flows/flows.ts
+++ b/src/vue-flows/flows.ts
@@ -1,32 +1,54 @@
 import { FlowsRoot } from './flows-root';
+import { VueConstructor } from 'vue'
 
-import MyComponent from './MyComponent.vue';
+export type Flow<TPayload = any,TResult = any> = {
+  key: FlowKey<TPayload,TResult> | string,
+  component: VueConstructor
+}
 
 export type FlowsOptions = {
-  hideCovered: boolean
+  hideCovered: boolean,
+  flows: Flow[]
 }
 
 const defaultOptions: FlowsOptions = {
   hideCovered: true,
+  flows: []
 }
 
+export class FlowKey<TPayload,TResult> {}
+
 export default class Flows {
-  private hideCovered: boolean;
+  public _hideCovered: boolean;
+  private flows: Flow[];
 
   constructor(options: FlowsOptions) {
-    const resOptions = { ...options, ...defaultOptions };
-    this.hideCovered = resOptions.hideCovered;
+    const resOptions = { ...defaultOptions, ...options };
+    this._hideCovered = resOptions.hideCovered;
+    this.flows = resOptions.flows;
+    console.log(this.flows);
   }
 
   private root: FlowsRoot | null = null;
 
-  public start() {
-    //TODO: implement
+  public start<TPayload,TResult>(
+      key: FlowKey<TPayload,TResult> | string,
+      // payload: TPayload,
+      // onfinish: (result: TResult) => void,
+      // oncancel: () => void
+    ) {
     if (this.root == null) {
       console.error("No root attached")
     }
     else {
-      this.root.start(MyComponent)
+      let flow = this.flows.find(f => f.key === key);
+      if (flow == null) {
+        throw new Error("Unknown flow! " + key);
+      }
+      else {
+        console.log("Starting: " + flow.key);
+        this.root.start(flow.component)
+      }
     }
   }
   public _attach(t: FlowsRoot) {

--- a/src/vue-flows/index.ts
+++ b/src/vue-flows/index.ts
@@ -1,6 +1,6 @@
 import { PluginObject, VueConstructor } from 'vue';
 import VueFlowsRoot from './flows-root';
-import Flows, { FlowsOptions } from './flows'
+import Flows, { FlowsOptions, Flow } from './flows'
 
 declare global {
   interface Window {
@@ -38,5 +38,6 @@ const VueFlows: PluginObject<any> = {
 
 export {
   VueFlows,
-  VueFlowsRoot
+  VueFlowsRoot,
+  Flow
 };

--- a/src/vue-flows/index.ts
+++ b/src/vue-flows/index.ts
@@ -1,4 +1,6 @@
 import { PluginObject, VueConstructor } from 'vue';
+import VueFlowsRoot from './flows-root';
+import Flows, { FlowsOptions } from './flows'
 
 declare global {
   interface Window {
@@ -6,23 +8,16 @@ declare global {
   }
 }
 
-export class Flows {
-  public start() {
-    //TODO: implement
-    console.log("Foobar");
-  }
-}
-
 const version = '__VERSION__';
 
-const install = (Vue: any, options: any): void => {
+const install = (Vue: any, options: FlowsOptions): void => {
 
-  if (VueModalFlows.installed) {
+  if (VueFlows.installed) {
     return;
   }
-  VueModalFlows.installed = true;
+  VueFlows.installed = true;
 
-  const flows = new Flows();
+  const flows = new Flows(options);
 
   Vue.$flows = flows;
 
@@ -36,9 +31,12 @@ const install = (Vue: any, options: any): void => {
 
 };
 
-const VueModalFlows: PluginObject<any> = {
+const VueFlows: PluginObject<any> = {
   install,
   version,
 };
 
-export default VueModalFlows;
+export {
+  VueFlows,
+  VueFlowsRoot
+};

--- a/src/vue-flows/vue.d.ts
+++ b/src/vue-flows/vue.d.ts
@@ -1,4 +1,4 @@
-import { Flows } from './vue-modal-flows'
+import Flows from './flows'
 
 declare module 'vue/types/vue' {
   interface Vue {


### PR DESCRIPTION
This adds a root component that can be added by simply changing `h(App)` to `h(VueFlowsRoot(App))`. The root component registers with the plugin when created, and the user can then start flows using `vue.$flows.start(key)`. Keys can be strings or FlowKey objects (which are generics, to allow type safety with flow payloads and results).